### PR TITLE
fix: validation for bucket_name variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -61,8 +61,8 @@ variable "bucket_name" {
     error_message = "Bucket name is not set."
   }
   validation {
-    condition     = !can(regex("[^A-Za-z-.]", var.bucket_name))
-    error_message = "The name of the bucket can contain only a-z, A-Z, \"-\" and \".\""
+    condition     = !can(regex("[^A-Za-z0-9-.]", var.bucket_name))
+    error_message = "The name of the bucket can contain only a-z, A-Z, 0-9, \"-\" and \".\""
   }
   default = null
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.